### PR TITLE
More user friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open-source analytics
 
-This project collects [npm download counts](https://github.com/npm/registry/blob/main/docs/download-counts.md) for [Observable’s open-source projects](https://github.com/observablehq) and [D3](https://github.com/d3). These charts are built with [Observable Framework](https://observablehq.com/framework/) and updated daily on [Observable Cloud](https://observablehq.com/platform/cloud) so they can be [embedded](https://observablehq.com/framework/embeds) in our GitHub READMEs. This project is [open-source](https://github.com/observablehq/oss-analytics/); fork it to build your own embeddable charts!
+This project collects [npm download counts](https://github.com/npm/registry/blob/main/docs/download-counts.md) for [Observable’s open-source projects](https://github.com/observablehq) and [D3](https://github.com/d3). These charts are built with [Observable Framework](https://observablehq.com/framework/) and updated daily on [Observable Cloud](https://observablehq.com/platform/cloud) so they can be [embedded](https://observablehq.com/framework/embeds) in our GitHub READMEs.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://observablehq.observablehq.cloud/oss-analytics/@observablehq/plot/downloads-dark.svg">
@@ -8,3 +8,13 @@ This project collects [npm download counts](https://github.com/npm/registry/blob
 </picture>
 
 <sub>Daily downloads of Observable Plot · [oss-analytics](https://observablehq.observablehq.cloud/oss-analytics/)</sub>
+
+
+## How to use for your own packages
+
+This project is [open-source](https://github.com/observablehq/oss-analytics/); fork it to build your own embeddable charts.
+
+1. Edit [observablehq.config.js](https://github.com/observablehq/oss-analytics/blob/main/observablehq.config.js) to list your npm packages.
+2. In your Observable account, add a new data app and link it to the forked repo.
+3. In the data app’s Automation tab, set a the build schedule to “daily”.
+4. Tweak [index.md.js](https://github.com/observablehq/oss-analytics/blob/main/src/index.md.js) to personalize the page.

--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@ This project collects [npm download counts](https://github.com/npm/registry/blob
 
 <sub>Daily downloads of Observable Plot · [oss-analytics](https://observablehq.observablehq.cloud/oss-analytics/)</sub>
 
-
 ## How to use for your own packages
 
 This project is [open-source](https://github.com/observablehq/oss-analytics/); fork it to build your own embeddable charts.
 
-1. Edit [observablehq.config.js](https://github.com/observablehq/oss-analytics/blob/main/observablehq.config.js) to list your npm packages.
-2. In your Observable account, add a new data app and link it to the forked repo.
-3. In the data app’s Automation tab, set a the build schedule to “daily”.
-4. Tweak [index.md.js](https://github.com/observablehq/oss-analytics/blob/main/src/index.md.js) to personalize the page.
+1. Edit [`observablehq.config.js`](https://github.com/observablehq/oss-analytics/blob/main/observablehq.config.js) to list your npm packages.
+2. In your [Observable workspace](https://observablehq.com), create a new data app and link it to the forked repo.
+3. In your new data app’s **Automation** tab, enable the `daily` build schedule.
+4. Tweak [`index.md.js`](https://github.com/observablehq/oss-analytics/blob/main/src/index.md.js) to personalize the page.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ This project collects [npm download counts](https://github.com/npm/registry/blob
 
 ## How to use for your own packages
 
-This project is [open-source](https://github.com/observablehq/oss-analytics/); fork it to build your own embeddable charts.
+This project is [open-source](https://github.com/observablehq/oss-analytics/); you can use it to build embeddable charts of your own packages.
 
-1. Edit [`observablehq.config.js`](https://github.com/observablehq/oss-analytics/blob/main/observablehq.config.js) to list your npm packages.
-2. In your [Observable workspace](https://observablehq.com), create a new data app and link it to the forked repo.
-3. In your new data app’s **Automation** tab, enable the `daily` build schedule.
-4. Tweak [`index.md.js`](https://github.com/observablehq/oss-analytics/blob/main/src/index.md.js) to personalize the page.
+1. [Fork this repository.](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo)
+2. Edit [`observablehq.config.js`](https://github.com/observablehq/oss-analytics/blob/main/observablehq.config.js) to list your npm packages, comitting your changes.
+3. In your [Observable workspace](https://observablehq.com), create a new data app and link it to your forked repository.
+4. In your new data app’s **Automation** tab, enable the `daily` build schedule.
+5. Tweak [`index.md.js`](https://github.com/observablehq/oss-analytics/blob/main/src/index.md.js) to personalize the page.

--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -1,81 +1,82 @@
-const observableNames = [
-  "@observablehq/framework",
-  "@observablehq/plot",
-  "@observablehq/inputs",
-  "@observablehq/runtime",
-  "@observablehq/stdlib",
-  "@observablehq/inspector",
-  "@observablehq/parser",
-  "htl"
-];
-
-const d3Names = [
-  "d3",
-  "d3-array",
-  "d3-axis",
-  "d3-brush",
-  "d3-chord",
-  "d3-collection",
-  "d3-color",
-  "d3-contour",
-  "d3-delaunay",
-  "d3-dispatch",
-  "d3-drag",
-  "d3-dsv",
-  "d3-ease",
-  "d3-fetch",
-  "d3-force",
-  "d3-format",
-  "d3-geo",
-  "d3-geo-polygon",
-  "d3-geo-projection",
-  "d3-hexbin",
-  "d3-hierarchy",
-  "d3-hsv",
-  "d3-interpolate",
-  "d3-path",
-  "d3-polygon",
-  "d3-quadtree",
-  "d3-queue",
-  "d3-random",
-  "d3-request",
-  "d3-require",
-  "d3-sankey",
-  "d3-scale",
-  "d3-scale-chromatic",
-  "d3-selection",
-  "d3-selection-multi",
-  "d3-shape",
-  "d3-tile",
-  "d3-time",
-  "d3-time-format",
-  "d3-timer",
-  "d3-transition",
-  "d3-voronoi",
-  "d3-zoom"
-];
-
 export const packages = [
-  ...observableNames.map((name) => ({
+  ...[
+    "@observablehq/framework",
+    "@observablehq/plot",
+    "@observablehq/inputs",
+    "@observablehq/runtime",
+    "@observablehq/stdlib",
+    "@observablehq/inspector",
+    "@observablehq/parser",
+    "htl"
+  ].map((name) => ({
     name,
     group: "Observable",
     href:
       name === "htl"
         ? "https://github.com/observablehq/htl"
-        : `https://github.com/${name.replace(/^@/, "")}`,
+        : `https://github.com/${name.replace(/^@/, "")}`
   })),
-  ...d3Names.map((name) => ({
+  ...[
+    "d3",
+    "d3-array",
+    "d3-axis",
+    "d3-brush",
+    "d3-chord",
+    "d3-color",
+    "d3-contour",
+    "d3-delaunay",
+    "d3-dispatch",
+    "d3-drag",
+    "d3-dsv",
+    "d3-ease",
+    "d3-fetch",
+    "d3-force",
+    "d3-format",
+    "d3-geo",
+    "d3-hierarchy",
+    "d3-interpolate",
+    "d3-path",
+    "d3-polygon",
+    "d3-quadtree",
+    "d3-random",
+    "d3-scale",
+    "d3-scale-chromatic",
+    "d3-selection",
+    "d3-shape",
+    "d3-time",
+    "d3-time-format",
+    "d3-timer",
+    "d3-transition",
+    "d3-zoom"
+  ].map((name) => ({
     name,
-    group: "D3",
-    href: `https://github.com/d3/${name}`,
+    group: "D3 (core)",
+    href: `https://github.com/d3/${name}`
   })),
+  ...[
+    "d3-collection",
+    "d3-geo-polygon",
+    "d3-geo-projection",
+    "d3-hexbin",
+    "d3-hsv",
+    "d3-queue",
+    "d3-request",
+    "d3-require",
+    "d3-sankey",
+    "d3-selection-multi",
+    "d3-tile",
+    "d3-voronoi"
+  ].map((name) => ({
+    name,
+    group: "D3 (non-core)",
+    href: `https://github.com/d3/${name}`
+  }))
 ];
 
 export default {
   title: "Open-source analytics",
   head: '<link rel="icon" href="observable.png" type="image/png" sizes="32x32">',
   root: "src",
-  // theme: ["dashboard"],
   style: "style.css",
   globalStylesheets: [
     "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Spline+Sans+Mono:ital,wght@0,300..700;1,300..700&display=swap"

--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -1,4 +1,4 @@
-export const observableNames = [
+const observableNames = [
   "@observablehq/framework",
   "@observablehq/plot",
   "@observablehq/inputs",
@@ -9,7 +9,7 @@ export const observableNames = [
   "htl"
 ];
 
-export const d3Names = [
+const d3Names = [
   "d3",
   "d3-array",
   "d3-axis",
@@ -55,6 +55,22 @@ export const d3Names = [
   "d3-zoom"
 ];
 
+export const packages = [
+  ...observableNames.map((name) => ({
+    name,
+    group: "Observable",
+    href:
+      name === "htl"
+        ? "https://github.com/observablehq/htl"
+        : `https://github.com/${name.replace(/^@/, "")}`,
+  })),
+  ...d3Names.map((name) => ({
+    name,
+    group: "D3",
+    href: `https://github.com/d3/${name}`,
+  })),
+];
+
 export default {
   title: "Open-source analytics",
   head: '<link rel="icon" href="observable.png" type="image/png" sizes="32x32">',
@@ -83,7 +99,7 @@ export default {
   </div>`,
   footer: ((date = new Date()) =>
     `© ${date.getUTCFullYear()} Observable, Inc. Updated <a title="${date.toISOString()}">${date.toLocaleDateString("en-US", {month: "short", day: "numeric", hour: "numeric", timeZone: "America/Los_Angeles"})} PT</a>.`)(),
-  dynamicPaths: [...observableNames, ...d3Names].flatMap((name) => [
+  dynamicPaths: packages.flatMap((name) => [
     `/${name}/downloads-dark.svg`,
     `/${name}/downloads.svg`
   ])

--- a/src/index.md.js
+++ b/src/index.md.js
@@ -1,23 +1,13 @@
-import {observableNames, d3Names} from "../observablehq.config.js";
+import {packages} from "../observablehq.config.js";
+import {groups} from "d3";
 
-const repoMap = new Map([
-  ...d3Names.map((name) => [name, `https://github.com/d3/${name}`]),
-  ...observableNames.map((name) => [name, `https://github.com/${name.replace(/^@/, "")}`]),
-  ["htl", "https://github.com/observablehq/htl"]
-]);
-
-function getRepo(name) {
-  if (!repoMap.has(name)) throw new Error(`unknown repo: ${name}`);
-  return repoMap.get(name);
-}
-
-function preview(name) {
+function preview({name, href})  {
   return `<div class="card" style="margin: 0;">
-    <h2>Daily downloads of <a href=${getRepo(name)}>${name}</a></h2>
-    <a href=${getRepo(name)}>
+    <h2>Daily downloads of <a href=${href}>${name}</a></h2>
+    <a href=${href}>
       <picture>
         <source media="(prefers-color-scheme: dark)" srcset="/${name}/downloads-dark.svg">
-        <img style="width: 100%;" alt="Daily downloads of Observable Plot" src="/${name}/downloads.svg">
+        <img style="width: 100%;" alt="Daily downloads of ${name}" src="/${name}/downloads.svg">
       </picture>
     </a>
   </div>`;
@@ -45,17 +35,9 @@ This project collects [npm download counts](https://github.com/npm/registry/blob
 
 ---
 
-## Observable
-
-<div class="wide-grid">
-  ${observableNames.map(preview).join("\n")}
-</div>
-
----
-
-## D3
-
-<div class="wide-grid">
-  ${d3Names.map(preview).join("\n")}
-</div>
+${groups(packages, ({group}) => group)
+.map(([group, packages]) => `## ${group}
+  <div class="wide-grid">
+    ${packages.map(preview).join("\n")}
+  </div>`).join("\n\n")}
 `);

--- a/src/index.md.js
+++ b/src/index.md.js
@@ -1,8 +1,8 @@
 import {packages} from "../observablehq.config.js";
 import {groups} from "d3";
 
-function preview({name, href})  {
-  return `<div class="card" style="margin: 0;">
+function preview({name, href}) {
+  return `<div class="card">
     <h2>Daily downloads of <a href=${href}>${name}</a></h2>
     <a href=${href}>
       <picture>
@@ -31,13 +31,17 @@ This project collects [npm download counts](https://github.com/npm/registry/blob
   }
 }
 
+.wide-grid .card {
+  margin: 0;
+}
+
 </style>
 
----
+${groups(packages, ({group}) => group).map(([group, packages]) => `---
 
-${groups(packages, ({group}) => group)
-.map(([group, packages]) => `## ${group}
-  <div class="wide-grid">
-    ${packages.map(preview).join("\n")}
-  </div>`).join("\n\n")}
+## ${group}
+
+<div class="wide-grid">
+  ${packages.map(preview).join("\n  ")}
+</div>`).join("\n\n")}
 `);


### PR DESCRIPTION
This PR tries to make it easier to get started when forking this project.

I'm also removing the currently unused `github.js`. If we start using it we'll have to add instructions about the GITHUB_TOKEN secret (where to get it, where to paste it). 