### PR TITLE
build the repo page

### DIFF
--- a/observablehq.config.js
+++ b/observablehq.config.js
@@ -101,6 +101,7 @@ export default {
   footer: ((date = new Date()) =>
     `© ${date.getUTCFullYear()} Observable, Inc. Last updated <a title="${date.toISOString()}">${date.toLocaleDateString("en-US", {month: "short", day: "numeric"})}</a>.`)(),
   dynamicPaths: packages.flatMap(({name}) => [
+    `/${name}`,
     `/${name}/downloads-dark.svg`,
     `/${name}/downloads.svg`
   ])


### PR DESCRIPTION
currently we 404 on https://observablehq.observablehq.cloud/oss-analytics/@observablehq/plot

I've tested that this works at https://observablehq.observablehq.cloud/open-source-analytics-test/@observablehq/plot (with a build limited to plot and framework—since I didn't want to wait 2 hours for it to build).

(Side note: it works on Observable Cloud, but doesn't work locally with `npx http-server` because the folder `/@observablehq/plot/` created for the image assets is served in priority over `/@observablehq/plot.html`.)