### PR TITLE
show change in table

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -9,6 +9,16 @@ export async function fetchGithub(path, options) {
   return (await requestGithub(path, options)).body;
 }
 
+export async function fetchGithubStargazersSinceCount(repo, since) {
+  let count = 0;
+  for await (const item of listGithub(`/repos/${repo}/stargazers`, {accept: "application/vnd.github.star+json"})) {
+    const starred_at = new Date(item.starred_at);
+    if (starred_at < since) break;
+    ++count;
+  }
+  return count;
+}
+
 export async function requestGithub(
   path,
   {accept = "application/vnd.github.v3+json"} = {}

--- a/src/index.md.js
+++ b/src/index.md.js
@@ -104,8 +104,18 @@ main th:last-child,
 main td,
 main td:last-child {
   height: 2rem;
-  padding: 0 1rem;
+  padding: 0 0.5rem;
   vertical-align: middle;
+}
+
+main th:first-child,
+main td:first-child {
+  padding-left: 1rem;
+}
+
+main th:last-child,
+main td:last-child {
+  padding-right: 1rem;
 }
 
 </style>
@@ -118,12 +128,12 @@ ${groups(packages, ({group}) => group)
   <thead>
     <tr>
       <th data-sort>name</th>
-      <th class="hide-if-small2" style="width: 12rem;" data-type="date" data-sort>latest release</th>
-      <th class="hide-if-small2"></th>
-      <th style="width: 10rem;" data-type="number" data-sort="desc">stars</th>
-      <th class="hide-if-small"></th>
-      <th style="width: 10rem;" data-type="number" data-sort><span class="hide-if-small">weekly</span> downloads</th>
-      <th class="hide-if-small"></th>
+      <th class="hide-if-small2" style="width: 6rem;" data-type="date" data-sort>latest release</th>
+      <th style="width: 3rem;" class="hide-if-small2"></th>
+      <th style="width: 6rem;" data-type="number" data-sort="desc">stars</th>
+      <th style="width: 2rem;" class="hide-if-small"></th>
+      <th style="width: 7rem;" data-type="number" data-sort><span class="hide-if-small">weekly</span> downloads</th>
+      <th style="width: 2rem;" class="hide-if-small"></th>
     </tr>
   </thead>
   <tbody>

--- a/src/npm.js
+++ b/src/npm.js
@@ -1,4 +1,4 @@
-import {utcDay} from "d3-time";
+import {utcDay, utcYear} from "d3-time";
 import {format as formatIso} from "isoformat";
 import {fetchCached as fetch} from "./fetch.js";
 
@@ -9,13 +9,13 @@ export async function fetchNpm(path) {
   return await response.json();
 }
 
-export async function fetchNpmDownloads(name, start = new Date("2021-01-01"), end = utcDay()) {
+export async function fetchNpmDownloads(name, start, end) {
   const data = [];
   let batchStart = end;
   let batchEnd;
   while (batchStart > start) {
     batchEnd = batchStart;
-    batchStart = utcDay.offset(batchStart, -365);
+    batchStart = utcYear(utcDay.offset(batchStart, -1)); // align on year for caching
     if (batchStart < start) batchStart = start;
     const formatStart = formatIso(batchStart);
     const formatEnd = formatIso(utcDay.offset(batchEnd, -1)); // inclusive end

--- a/src/style.css
+++ b/src/style.css
@@ -101,6 +101,12 @@ h1 {
   }
 }
 
+@container not (min-width: 720px) {
+  .hide-if-small2 {
+    display: none !important;
+  }
+}
+
 @media (min-width: calc(640px + 6rem + 272px)) {
   #observablehq-sidebar-toggle:is(:checked, :indeterminate) ~ #observablehq-center .hide-if-sidebar {
     display: none !important;


### PR DESCRIPTION
This…

* Shows added stars since last week
* Shows change in weekly downloads compared to last week
* Aligns the “latest release” header with the version number
* Changes the table background color to alt (like we do with cards)
* Gives npm at least six hours to compute download statistics for the previous day
* Aligns the npm fetches on yearly boundaries for better caching

After:
<img width="1112" alt="Screenshot 2024-10-18 at 7 14 00 PM" src="https://github.com/user-attachments/assets/e896eb4a-2358-458b-9221-d39a0290f864">

Before:
<img width="1112" alt="Screenshot 2024-10-18 at 7 14 56 PM" src="https://github.com/user-attachments/assets/1d11b440-d66d-49a3-8184-01c2f8e1b675">
