### PR TITLE
issues burndown

### DIFF
--- a/src/npm.js
+++ b/src/npm.js
@@ -10,7 +10,7 @@ export async function fetchNpm(path) {
   return await response.json();
 }
 
-export async function fetchNpmDownloads(name, start = new Date("2021-01-01"), end = today) {
+export async function fetchNpmDownloads(name, start = utcYear.offset(today, -3), end = today) {
   const data = [];
   let batchStart = end;
   let batchEnd;


### PR DESCRIPTION
Adds an issues burndown chart (modeled after [Tom’s](https://observablehq.com/@tmcw/github-burndown), [reimplemented here](https://observablehq.com/@observablehq/plot-burndown-chart)).

<img width="1624" alt="Screenshot 2024-10-19 at 9 38 51 AM" src="https://github.com/user-attachments/assets/1f1c6f44-7f2b-4f97-89c8-f10fbd91ccb5">

This is essentially ready, but it is a bit slow to render and could be improved. Perhaps we should write a custom mark that uses canvas. And it would be cool if you could hover over the chart and see the titles of specific issues, not just when they are opened.